### PR TITLE
Add replacement rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ $ sudo /usr/lib64/fluent/ruby/bin/fluent-gem install fluent-plugin-rename-key
 # <new_key> is the string with MatchData placeholder for creating the new key name, whitespace is allowed
 rename_rule<num> <key_regexp> <new_key>
 
+# <num> is an integer, used to sort and apply the rules
+# <key_regexp> is the regular expression used to match the keys, whitespace is not allowed, use "\s" instead
+# <new_key> is the string to replace the matches with, with MatchData placeholder for creating the new key name, whitespace is allowed. Optional, if missing then the matches are removed
+replace_rule<num> <key_regexp> <new_key>
+
 # Optional: remove tag prefix
 remove_tag_prefix <string>
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec) do |spec|
     spec.pattern = 'spec/**/*_spec.rb'
-    spec.rspec_opts = ['-cfs']
+    spec.rspec_opts = ['-cfd']
   end
 rescue LoadError => e
 end

--- a/fluent-plugin-rename-key.gemspec
+++ b/fluent-plugin-rename-key.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'coveralls'
+  gem.add_development_dependency 'test-unit'
 
 end

--- a/spec/plugin/out_rename_key_spec.rb
+++ b/spec/plugin/out_rename_key_spec.rb
@@ -67,10 +67,30 @@ describe Fluent::RenameKeyOutput do
   context "private methods" do
     describe "#parse_rename_rule" do
       let(:rename_rule_example) { '^\$(.+) ${md[1]}' }
-      let(:result) { Fluent::RenameKeyOutput.new.parse_rename_rule rename_rule_example }
+      let(:rename_rule_result) { Fluent::RenameKeyOutput.new.parse_rename_rule rename_rule_example }
 
       it "captures 2 items, the key_regexp and new_name" do
-        expect(result.size).to eq 2
+        expect(rename_rule_result.size).to eq 2
+      end
+    end
+
+    describe "#parse_replace_rule" do
+      let(:replace_rule_example1) { '- _' } # Replace hyphens with underscores
+      let(:replace_rule_result1) { Fluent::RenameKeyOutput.new.parse_replace_rule replace_rule_example1 }
+
+      let(:replace_rule_example2) { '[()-\s]' } # Remove all parethesis hyphens and spaces
+      let(:replace_rule_result2) { Fluent::RenameKeyOutput.new.parse_replace_rule replace_rule_example2 }
+
+      it "captures 2 items, the key_regexp and replacement" do
+        expect(replace_rule_result1.size).to eq 2
+        expect(replace_rule_result1[0]).to eq '-'
+        expect(replace_rule_result1[1]).to eq '_'
+      end
+
+      it "captures 1 items, the key_regexp to remove" do
+        expect(replace_rule_result2.size).to eq 2
+        expect(replace_rule_result2[0]).to eq '[()-\s]'
+        expect(replace_rule_result2[1]).to eq nil
       end
     end
 
@@ -128,6 +148,75 @@ describe Fluent::RenameKeyOutput do
         result = d.emits[0][2]
         expect(result).to have_key 'eve_2'
         expect(result['eve_2']).to have_key 'x$1'
+      end
+    end
+
+    describe "#replace_key" do
+
+      it "replace key name which matches the key_regexp at all level" do
+        d = create_driver %q[
+          replace_rule1 ^(\$) x
+        ]
+        d.run do
+          d.emit '$url' => 'www.google.com', 'level2' => {'id'=>'something', 'a'=>{'$1' => 'option1'}}
+        end
+        result = d.emits[0][2]
+        p result
+        expect(result).to have_key 'xurl'
+        expect(result['level2']['a']).to have_key 'x1'
+      end
+
+      it "replace key name only at the first level when deep_rename is false" do
+        d = create_driver %q[
+          replace_rule1 ^\$ x
+          deep_rename false
+        ]
+        d.run do
+          d.emit '$url' => 'www.google.com', 'level2' => {'id'=>'something', 'a'=>{'$1' => 'option1'}}
+        end
+        result = d.emits[0][2]
+        expect(result).to have_key 'xurl'
+        expect(result['level2']['a']).to have_key '$1'
+      end
+
+      it "replace key of hashes in an array" do
+        d = create_driver 'replace_rule1 ^(\$) x${md[1]}'
+        d.run do
+          d.emit 'array' => [{'$url jump' => 'www.google.com'}, {'$url run' => 'www.google.com'}], 'level2' => {'$1' => 'options1'}
+        end
+        result = d.emits[0][2]
+        expect(result['array'][0]).to have_key 'x$url jump'
+        expect(result['array'][1]).to have_key 'x$url run'
+      end
+
+      it "replaces key name using match data" do
+        d = create_driver 'replace_rule1 ^\$(url) x${md[1]}'
+        d.run do
+          d.emit '$url jump' => 'www.google.com', 'level2' => {'$1' => 'options1'}
+        end
+        result = d.emits[0][2]
+        expect(result).to have_key 'xurl jump'
+      end
+
+      it "removes certain characters from key" do
+        d = create_driver 'replace_rule1 [\s/()]'
+        d.run do
+          d.emit 'us/op (read)' => 42
+        end
+        result = d.emits[0][2]
+        expect(result).to have_key 'usopread'
+      end
+
+      it "replaces key using multiple rules" do
+        d = create_driver %q[
+          rename_rule1 ^(.+)$ lt_${md[1]}
+          replace_rule1 - _
+        ]
+        d.run do
+          d.emit '100u-200u' => 23
+        end
+        result = d.emits[0][2]
+        expect(result).to have_key 'lt_100u_200u'
       end
     end
   end

--- a/spec/plugin/out_rename_key_spec.rb
+++ b/spec/plugin/out_rename_key_spec.rb
@@ -70,7 +70,7 @@ describe Fluent::RenameKeyOutput do
       let(:result) { Fluent::RenameKeyOutput.new.parse_rename_rule rename_rule_example }
 
       it "captures 2 items, the key_regexp and new_name" do
-        expect(result).to have(2).items
+        expect(result.size).to eq 2
       end
     end
 


### PR DESCRIPTION
Added a rule where you can replace parts of keys, or remove those. For example:

```
<match input.test>
  @type rename_key
  replace_rule1 '[\s/()]'
</match>
```

The above rule would transform `'us/op (read)' => 3` into `'usopread' => 3`

```
<match input.test>
  @type rename_key
  rename_rule1 ^(.+)$ lt_${md[1]}
  replace_rule1 - _
</match>
```

The above rule would transform `'100u-200u' => 3` into `'lt_100u_200u' => 3`