### PR TITLE
Add filter version of rename_key plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
   - 2.3.0
   - 2.2
-  - 1.9.3
 
 # to avoid travis-ci issue since 2015-12-25
 before_install:

--- a/lib/fluent/plugin/filter_rename_key.rb
+++ b/lib/fluent/plugin/filter_rename_key.rb
@@ -1,5 +1,9 @@
+require 'fluent/plugin/rename_key_util'
+
 class Fluent::RenameKeyFilter < Fluent::Filter
   Fluent::Plugin.register_filter 'rename_key', self
+
+  include Fluent::RenameKeyUtil
 
   desc 'Deep rename/replace operation.'
   config_param :deep_rename, :bool, default: true
@@ -7,43 +11,8 @@ class Fluent::RenameKeyFilter < Fluent::Filter
   def configure conf
     super
 
-    @rename_rules = []
-    conf_rename_rules = conf.keys.select { |k| k =~ /^rename_rule(\d+)$/ }
-    conf_rename_rules.sort_by { |r| r.sub('rename_rule', '').to_i }.each do |r|
-      key_regexp, new_key = parse_rename_rule conf[r]
-
-      if key_regexp.nil? || new_key.nil?
-        raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
-      end
-
-      if @rename_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
-        raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@rename_rules}"
-      end
-
-      @rename_rules << { key_regexp: /#{key_regexp}/, new_key: new_key }
-      log.info "Added rename key rule: #{r} #{@rename_rules.last}"
-    end
-
-    @replace_rules = []
-    conf_replace_rules = conf.keys.select { |k| k =~ /^replace_rule(\d+)$/ }
-    conf_replace_rules.sort_by { |r| r.sub('replace_rule', '').to_i }.each do |r|
-      key_regexp, replacement = parse_replace_rule conf[r]
-
-      if key_regexp.nil?
-        raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
-      end
-
-      if replacement.nil?
-          replacement = ""
-      end
-
-      if @replace_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
-        raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@replace_rules}"
-      end
-
-      @replace_rules << { key_regexp: /#{key_regexp}/, replacement: replacement }
-      log.info "Added replace key rule: #{r} #{@replace_rules.last}"
-    end
+    create_rename_rules(conf)
+    create_replace_rules(conf)
 
     raise Fluent::ConfigError, "No rename or replace rules are given" if @rename_rules.empty? && @replace_rules.empty?
   end
@@ -53,81 +22,4 @@ class Fluent::RenameKeyFilter < Fluent::Filter
     new_record = replace_key new_record
     new_record
   end
-
-  # private
-
-  def parse_rename_rule rule
-    $~.captures if rule.match /^([^\s]+)\s+(.+)$/
-  end
-
-  def parse_replace_rule rule
-    $~.captures if rule.match /^([^\s]+)(?:\s+(.+))?$/
-  end
-
-  def rename_key record
-    new_record = {}
-
-    record.each do |key, value|
-
-      @rename_rules.each do |rule|
-        match_data = key.match rule[:key_regexp]
-        next unless match_data # next rule
-
-        placeholder = get_placeholder match_data
-        key = rule[:new_key].gsub /\${md\[\d+\]}/, placeholder
-        break
-      end
-
-      if @deep_rename
-        if value.is_a? Hash
-          value = rename_key value
-        elsif value.is_a? Array
-          value = value.map { |v| v.is_a?(Hash) ? rename_key(v) : v }
-        end
-      end
-
-      new_record[key] = value
-    end
-
-    new_record
-  end
-
-  def replace_key record
-    new_record = {}
-
-    record.each do |key, value|
-
-      @replace_rules.each do |rule|
-        match_data = key.match rule[:key_regexp]
-        next unless match_data # next rule
-
-        placeholder = get_placeholder match_data
-        key = key.gsub rule[:key_regexp], rule[:replacement].gsub(/\${md\[\d+\]}/, placeholder)
-        break
-      end
-
-      if @deep_rename
-        if value.is_a? Hash
-          value = replace_key value
-        elsif value.is_a? Array
-          value = value.map { |v| v.is_a?(Hash) ? replace_key(v) : v }
-        end
-      end
-
-      new_record[key] = value
-    end
-
-    new_record
-  end
-
-  def get_placeholder match_data
-    placeholder = {}
-
-    match_data.to_a.each_with_index do |e, idx|
-      placeholder["${md[#{idx}]}"] = e
-    end
-
-    placeholder
-  end
-
 end if defined?(Fluent::Filter)

--- a/lib/fluent/plugin/filter_rename_key.rb
+++ b/lib/fluent/plugin/filter_rename_key.rb
@@ -1,0 +1,133 @@
+class Fluent::RenameKeyFilter < Fluent::Filter
+  Fluent::Plugin.register_filter 'rename_key', self
+
+  desc 'Deep rename/replace operation.'
+  config_param :deep_rename, :bool, default: true
+
+  def configure conf
+    super
+
+    @rename_rules = []
+    conf_rename_rules = conf.keys.select { |k| k =~ /^rename_rule(\d+)$/ }
+    conf_rename_rules.sort_by { |r| r.sub('rename_rule', '').to_i }.each do |r|
+      key_regexp, new_key = parse_rename_rule conf[r]
+
+      if key_regexp.nil? || new_key.nil?
+        raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
+      end
+
+      if @rename_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
+        raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@rename_rules}"
+      end
+
+      @rename_rules << { key_regexp: /#{key_regexp}/, new_key: new_key }
+      log.info "Added rename key rule: #{r} #{@rename_rules.last}"
+    end
+
+    @replace_rules = []
+    conf_replace_rules = conf.keys.select { |k| k =~ /^replace_rule(\d+)$/ }
+    conf_replace_rules.sort_by { |r| r.sub('replace_rule', '').to_i }.each do |r|
+      key_regexp, replacement = parse_replace_rule conf[r]
+
+      if key_regexp.nil?
+        raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
+      end
+
+      if replacement.nil?
+          replacement = ""
+      end
+
+      if @replace_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
+        raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@replace_rules}"
+      end
+
+      @replace_rules << { key_regexp: /#{key_regexp}/, replacement: replacement }
+      log.info "Added replace key rule: #{r} #{@replace_rules.last}"
+    end
+
+    raise Fluent::ConfigError, "No rename or replace rules are given" if @rename_rules.empty? && @replace_rules.empty?
+  end
+
+  def filter tag, time, record
+    new_record = rename_key record
+    new_record = replace_key new_record
+    new_record
+  end
+
+  # private
+
+  def parse_rename_rule rule
+    $~.captures if rule.match /^([^\s]+)\s+(.+)$/
+  end
+
+  def parse_replace_rule rule
+    $~.captures if rule.match /^([^\s]+)(?:\s+(.+))?$/
+  end
+
+  def rename_key record
+    new_record = {}
+
+    record.each do |key, value|
+
+      @rename_rules.each do |rule|
+        match_data = key.match rule[:key_regexp]
+        next unless match_data # next rule
+
+        placeholder = get_placeholder match_data
+        key = rule[:new_key].gsub /\${md\[\d+\]}/, placeholder
+        break
+      end
+
+      if @deep_rename
+        if value.is_a? Hash
+          value = rename_key value
+        elsif value.is_a? Array
+          value = value.map { |v| v.is_a?(Hash) ? rename_key(v) : v }
+        end
+      end
+
+      new_record[key] = value
+    end
+
+    new_record
+  end
+
+  def replace_key record
+    new_record = {}
+
+    record.each do |key, value|
+
+      @replace_rules.each do |rule|
+        match_data = key.match rule[:key_regexp]
+        next unless match_data # next rule
+
+        placeholder = get_placeholder match_data
+        key = key.gsub rule[:key_regexp], rule[:replacement].gsub(/\${md\[\d+\]}/, placeholder)
+        break
+      end
+
+      if @deep_rename
+        if value.is_a? Hash
+          value = replace_key value
+        elsif value.is_a? Array
+          value = value.map { |v| v.is_a?(Hash) ? replace_key(v) : v }
+        end
+      end
+
+      new_record[key] = value
+    end
+
+    new_record
+  end
+
+  def get_placeholder match_data
+    placeholder = {}
+
+    match_data.to_a.each_with_index do |e, idx|
+      placeholder["${md[#{idx}]}"] = e
+    end
+
+    placeholder
+  end
+
+end if defined?(Fluent::Filter)

--- a/lib/fluent/plugin/out_rename_key.rb
+++ b/lib/fluent/plugin/out_rename_key.rb
@@ -1,5 +1,9 @@
+require 'fluent/plugin/rename_key_util'
+
 class Fluent::RenameKeyOutput < Fluent::Output
   Fluent::Plugin.register_output 'rename_key', self
+
+  include Fluent::RenameKeyUtil
 
   # To support Fluentd v0.10.57 or earlier
   unless method_defined?(:router)
@@ -31,43 +35,8 @@ class Fluent::RenameKeyOutput < Fluent::Output
   def configure conf
     super
 
-    @rename_rules = []
-    conf_rename_rules = conf.keys.select { |k| k =~ /^rename_rule(\d+)$/ }
-    conf_rename_rules.sort_by { |r| r.sub('rename_rule', '').to_i }.each do |r|
-      key_regexp, new_key = parse_rename_rule conf[r]
-
-      if key_regexp.nil? || new_key.nil?
-        raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
-      end
-
-      if @rename_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
-        raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@rename_rules}"
-      end
-
-      @rename_rules << { key_regexp: /#{key_regexp}/, new_key: new_key }
-      log.info "Added rename key rule: #{r} #{@rename_rules.last}"
-    end
-
-    @replace_rules = []
-    conf_replace_rules = conf.keys.select { |k| k =~ /^replace_rule(\d+)$/ }
-    conf_replace_rules.sort_by { |r| r.sub('replace_rule', '').to_i }.each do |r|
-      key_regexp, replacement = parse_replace_rule conf[r]
-
-      if key_regexp.nil?
-        raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
-      end
-
-      if replacement.nil?
-          replacement = ""
-      end
-
-      if @replace_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
-        raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@replace_rules}"
-      end
-
-      @replace_rules << { key_regexp: /#{key_regexp}/, replacement: replacement }
-      log.info "Added replace key rule: #{r} #{@replace_rules.last}"
-    end
+    create_rename_rules(conf)
+    create_replace_rules(conf)
 
     raise Fluent::ConfigError, "No rename or replace rules are given" if @rename_rules.empty? && @replace_rules.empty?
 
@@ -85,81 +54,4 @@ class Fluent::RenameKeyOutput < Fluent::Output
 
     chain.next
   end
-
-  # private
-
-  def parse_rename_rule rule
-    $~.captures if rule.match /^([^\s]+)\s+(.+)$/
-  end
-
-  def parse_replace_rule rule
-    $~.captures if rule.match /^([^\s]+)(?:\s+(.+))?$/
-  end
-
-  def rename_key record
-    new_record = {}
-
-    record.each do |key, value|
-
-      @rename_rules.each do |rule|
-        match_data = key.match rule[:key_regexp]
-        next unless match_data # next rule
-
-        placeholder = get_placeholder match_data
-        key = rule[:new_key].gsub /\${md\[\d+\]}/, placeholder
-        break
-      end
-
-      if @deep_rename
-        if value.is_a? Hash
-          value = rename_key value
-        elsif value.is_a? Array
-          value = value.map { |v| v.is_a?(Hash) ? rename_key(v) : v }
-        end
-      end
-
-      new_record[key] = value
-    end
-
-    new_record
-  end
-
-  def replace_key record
-    new_record = {}
-
-    record.each do |key, value|
-
-      @replace_rules.each do |rule|
-        match_data = key.match rule[:key_regexp]
-        next unless match_data # next rule
-
-        placeholder = get_placeholder match_data
-        key = key.gsub rule[:key_regexp], rule[:replacement].gsub(/\${md\[\d+\]}/, placeholder)
-        break
-      end
-
-      if @deep_rename
-        if value.is_a? Hash
-          value = replace_key value
-        elsif value.is_a? Array
-          value = value.map { |v| v.is_a?(Hash) ? replace_key(v) : v }
-        end
-      end
-
-      new_record[key] = value
-    end
-
-    new_record
-  end
-
-  def get_placeholder match_data
-    placeholder = {}
-
-    match_data.to_a.each_with_index do |e, idx|
-      placeholder["${md[#{idx}]}"] = e
-    end
-
-    placeholder
-  end
-
 end

--- a/lib/fluent/plugin/rename_key_util.rb
+++ b/lib/fluent/plugin/rename_key_util.rb
@@ -1,0 +1,119 @@
+module Fluent
+  module RenameKeyUtil
+    def create_rename_rules(conf)
+      @rename_rules = []
+      conf_rename_rules = conf.keys.select { |k| k =~ /^rename_rule(\d+)$/ }
+      conf_rename_rules.sort_by { |r| r.sub('rename_rule', '').to_i }.each do |r|
+        key_regexp, new_key = parse_rename_rule conf[r]
+
+        if key_regexp.nil? || new_key.nil?
+          raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
+        end
+
+        if @rename_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
+          raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@rename_rules}"
+        end
+
+        @rename_rules << { key_regexp: /#{key_regexp}/, new_key: new_key }
+        log.info "Added rename key rule: #{r} #{@rename_rules.last}"
+      end
+    end
+
+    def create_replace_rules(conf)
+      @replace_rules = []
+      conf_replace_rules = conf.keys.select { |k| k =~ /^replace_rule(\d+)$/ }
+      conf_replace_rules.sort_by { |r| r.sub('replace_rule', '').to_i }.each do |r|
+        key_regexp, replacement = parse_replace_rule conf[r]
+
+        if key_regexp.nil?
+          raise Fluent::ConfigError, "Failed to parse: #{r} #{conf[r]}"
+        end
+
+        if replacement.nil?
+          replacement = ""
+        end
+
+        if @replace_rules.map { |r| r[:key_regexp] }.include? /#{key_regexp}/
+          raise Fluent::ConfigError, "Duplicated rules for key #{key_regexp}: #{@replace_rules}"
+        end
+
+        @replace_rules << { key_regexp: /#{key_regexp}/, replacement: replacement }
+        log.info "Added replace key rule: #{r} #{@replace_rules.last}"
+      end
+    end
+
+    def parse_rename_rule rule
+      $~.captures if rule.match /^([^\s]+)\s+(.+)$/
+    end
+
+    def parse_replace_rule rule
+      $~.captures if rule.match /^([^\s]+)(?:\s+(.+))?$/
+    end
+
+    def rename_key record
+      new_record = {}
+
+      record.each do |key, value|
+
+        @rename_rules.each do |rule|
+          match_data = key.match rule[:key_regexp]
+          next unless match_data # next rule
+
+          placeholder = get_placeholder match_data
+          key = rule[:new_key].gsub /\${md\[\d+\]}/, placeholder
+          break
+        end
+
+        if @deep_rename
+          if value.is_a? Hash
+            value = rename_key value
+          elsif value.is_a? Array
+            value = value.map { |v| v.is_a?(Hash) ? rename_key(v) : v }
+          end
+        end
+
+        new_record[key] = value
+      end
+
+      new_record
+    end
+
+    def replace_key record
+      new_record = {}
+
+      record.each do |key, value|
+
+        @replace_rules.each do |rule|
+          match_data = key.match rule[:key_regexp]
+          next unless match_data # next rule
+
+          placeholder = get_placeholder match_data
+          key = key.gsub rule[:key_regexp], rule[:replacement].gsub(/\${md\[\d+\]}/, placeholder)
+          break
+        end
+
+        if @deep_rename
+          if value.is_a? Hash
+            value = replace_key value
+          elsif value.is_a? Array
+            value = value.map { |v| v.is_a?(Hash) ? replace_key(v) : v }
+          end
+        end
+
+        new_record[key] = value
+      end
+
+      new_record
+    end
+
+    def get_placeholder match_data
+      placeholder = {}
+
+      match_data.to_a.each_with_index do |e, idx|
+        placeholder["${md[#{idx}]}"] = e
+      end
+
+      placeholder
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,9 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/out_rename_key'
+if defined?(Fluent::Filter)
+  require 'fluent/plugin/filter_rename_key'
+end
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_filter_rename_key.rb
+++ b/test/plugin/test_filter_rename_key.rb
@@ -1,0 +1,215 @@
+require 'helper'
+
+class RenameKeyFilterTest < Test::Unit::TestCase
+  MATCH_TAG = 'incoming_tag'
+  RENAME_RULE_CONFIG = 'rename_rule1 ^\$(.+) x$${md[1]}'
+  REPLACE_RULE_CONFIG = 'replace_rule1 ^\$ x'
+
+  def setup
+    omit("Fluentd v0.12 or later is required.") unless defined?(Fluent::Filter)
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf, tag = MATCH_TAG)
+    Fluent::Test::FilterTestDriver.new(Fluent::RenameKeyFilter, tag).configure(conf)
+  end
+
+  def test_config_error
+    assert_raise(Fluent::ConfigError) { create_driver('') }
+
+    assert_raise(Fluent::ConfigError) { create_driver('rename_rule1 ^$(.+?) ') }
+
+    assert_raise(Fluent::ConfigError) {
+      config_dup_rules_for_a_key = %q[
+        rename_rule1 ^\$(.+) ${md[1]}
+        rename_rule2 ^\$(.+) ${md[1]} something
+      ]
+      create_driver(config_dup_rules_for_a_key)
+    }
+  end
+
+  def test_config_success
+    config_multiple_rules = %q[
+      rename_rule1 ^\$(.+)1 x$${md[1]}
+      rename_rule2 ^\$(.+)2(\d+) ${md[1]}_${md[2]}
+    ]
+
+    d = create_driver config_multiple_rules
+    assert_equal '^\$(.+)1 x$${md[1]}', d.instance.config['rename_rule1']
+    assert_equal '^\$(.+)2(\d+) ${md[1]}_${md[2]}', d.instance.config['rename_rule2']
+  end
+
+  def test_parse_rename_rule
+    parsed = Fluent::RenameKeyOutput.new.parse_rename_rule '(reg)(exp) ${md[1]} ${md[2]}'
+    assert_equal 2, parsed.length
+    assert_equal '(reg)(exp)', parsed[0]
+    assert_equal '${md[1]} ${md[2]}', parsed[1]
+  end
+
+  def test_parse_replace_rule_with_replacement
+    # Replace hyphens with underscores
+    parsed = Fluent::RenameKeyOutput.new.parse_replace_rule '- _'
+    assert_equal 2, parsed.length
+    assert_equal '-', parsed[0]
+    assert_equal '_', parsed[1]
+  end
+
+  def test_parse_replace_rule_without_replacement
+    # Remove all parethesis hyphens and spaces
+    parsed = Fluent::RenameKeyOutput.new.parse_replace_rule '[()-\s]'
+    assert_equal 2, parsed.length
+    assert_equal '[()-\s]', parsed[0]
+    assert parsed[1].nil?
+  end
+
+  def test_rename_rule_emit_deep_rename_hash
+    d = create_driver RENAME_RULE_CONFIG
+    d.run do
+      d.emit '$key1' => 'value1', 'key2' => {'$key3' => 'value3', '$key4'=> {'$key5' => 'value5'} }
+    end
+
+    emits = d.emits
+    assert_equal %w[x$key1 key2], emits[0][2].keys
+    assert_equal %w[x$key3 x$key4], emits[0][2]['key2'].keys
+    assert_equal ['x$key5'], emits[0][2]['key2']['x$key4'].keys
+  end
+
+  def test_rename_rule_emit_deep_rename_array
+    d = create_driver RENAME_RULE_CONFIG
+    d.run do
+      d.emit '$key1' => 'value1', 'key2' => [{'$key3' => 'value3'}, {'$key4'=> {'$key5' => 'value5'}}]
+    end
+
+    emits = d.emits
+    assert_equal %w[x$key3 x$key4], emits[0][2]['key2'].flat_map(&:keys)
+    assert_equal ['x$key5'], emits[0][2]['key2'][1]['x$key4'].keys
+  end
+
+  def test_rename_rule_emit_deep_rename_off
+    config = %Q[
+      #{RENAME_RULE_CONFIG}
+      deep_rename false
+    ]
+
+    d = create_driver config
+    d.run do
+      d.emit '$key1' => 'value1', 'key2' => {'$key3'=>'value3', '$key4'=> 'value4'}
+    end
+
+    emits = d.emits
+    assert_equal %w[$key3 $key4], emits[0][2]['key2'].keys
+  end
+
+  def test_rename_rule_emit_with_match_data
+    d = create_driver 'rename_rule1 (\w+)\s(\w+)\s(\w+) ${md[3]} ${md[2]} ${md[1]}'
+    d.run do
+      d.emit 'key1 key2 key3' => 'value'
+    end
+    emits = d.emits
+    assert_equal 1, emits.length
+    assert_equal ['key3 key2 key1'], emits[0][2].keys
+  end
+
+  def test_multiple_rename_rules_emit
+    config_multiple_rules = %q[
+      rename_rule1 ^(\w+)\s1 ${md[1]}_1
+      rename_rule2 ^(\w+)\s2 ${md[1]}_2
+    ]
+
+    d = create_driver config_multiple_rules
+    d.run do
+      d.emit 'key 1' => 'value1', 'key 2' => 'value2'
+    end
+
+    emits = d.emits
+    assert_equal %w[key_1 key_2], emits[0][2].keys
+  end
+
+  def test_replace_rule_emit_deep_rename_hash
+    d = create_driver 'replace_rule1 ^(\$) x'
+
+    d.run do
+      d.emit '$key1' => 'value1', 'key2' => { 'key3' => 'value3', '$key4' => 'value4' }
+    end
+    emits = d.emits
+    assert_equal %w[xkey1 key2], emits[0][2].keys
+    assert_equal %w[key3 xkey4], emits[0][2]['key2'].keys
+  end
+
+  def test_replace_rule_emit_with_match_data
+    d = create_driver 'rename_rule1 (\w+)\s(\w+)\s(\w+) ${md[3]} ${md[2]} ${md[1]}'
+    d.run do
+      d.emit 'key1 key2 key3' => 'value'
+    end
+    emits = d.emits
+    assert_equal 1, emits.length
+    assert_equal ['key3 key2 key1'], emits[0][2].keys
+  end
+
+  def test_replace_rule_emit_deep_rename_array
+    d = create_driver 'replace_rule1 ^(\$) x${md[1]}'
+
+    d.run do
+      d.emit '$key1' => 'value1', 'key2' => [{'$key3' => 'value3'}, {'$key4' => {'$key5' => 'value5'}}]
+    end
+
+    emits = d.emits
+    assert_equal %w[x$key3 x$key4], emits[0][2]['key2'].flat_map(&:keys)
+    assert_equal %w[x$key5], emits[0][2]['key2'][1]['x$key4'].keys
+  end
+
+  def test_replace_rule_emit_deep_rename_off
+    config = %Q[
+      #{REPLACE_RULE_CONFIG}
+      deep_rename false
+    ]
+
+    d = create_driver config
+    d.run do
+      d.emit '$key1' => 'value1', 'key2' => {'$key3'=>'value3', '$key4'=> 'value4'}
+    end
+
+    emits = d.emits
+    assert_equal %w[$key3 $key4], emits[0][2]['key2'].keys
+  end
+
+  def test_replace_rule_emit_remove_matched_when_no_replacement
+    d = create_driver 'replace_rule1 [\s/()]'
+    d.run do
+      d.emit 'key (/1 )' => 'value1'
+    end
+
+    emits = d.emits
+    assert_equal %w[key1], emits[0][2].keys
+  end
+
+  def test_multiple_replace_rules_emit
+    config_multiple_rules = %q[
+      replace_rule1 ^(\w+)\s(\d) ${md[1]}${md[2]}
+      replace_rule2 [\s()]
+    ]
+
+    d = create_driver config_multiple_rules
+    d.run do
+      d.emit 'key 1' => 'value1', 'key (2)' => 'value2'
+    end
+
+    emits = d.emits
+    assert_equal %w[key1 key2], emits[0][2].keys
+  end
+
+  def test_combined_rename_rule_and_replace_rule
+    config_combined_rules = %q[
+      rename_rule1 ^(.+)\s(one) ${md[1]}1
+      replace_rule2 [\s()]
+    ]
+
+    d = create_driver config_combined_rules
+    d.run do
+      d.emit '(key) one (x)' => 'value1', 'key (2)' => 'value2'
+    end
+
+    emits = d.emits
+    assert_equal %w[key1 key2], emits[0][2].keys
+  end
+end


### PR DESCRIPTION
Hi, I've tried to add filter version of rename_key plugin.
Someone would love to have filter version of this plugin.
It will solve issue #9.

**Notice:** v0.12's filter plugin does not have a functionality to modify tag and time.
If someone wants to modify time in filter plugin, we recommends to migrate to depends on v0.14 Filter Plugin API.
v0.14's Filter API has `#filter_with_time` method.